### PR TITLE
fix(web): enforce stricter types for ESLint checks

### DIFF
--- a/server/src/controllers/taskController.ts
+++ b/server/src/controllers/taskController.ts
@@ -233,19 +233,9 @@ export const taskController = {
       const parseLimit = parseInt(limit || String(DEFAULT_PAGE_SIZE))
       const validLimit = Math.min(Math.max(1, parseLimit), MAX_PAGE_SIZE)
 
-      // Parse cursor if provided
-      let cursorData
-      if (cursor) {
-        try {
-          cursorData = JSON.parse(Buffer.from(cursor, 'base64').toString())
-        } catch (e) {
-          return c.json({ error: 'Invalid cursor' }, 400)
-        }
-      }
-
       const result = await taskService.listTasks({
         limit: validLimit,
-        cursor: cursorData,
+        cursor,
       })
 
       return c.json({

--- a/server/src/controllers/uploadsController.ts
+++ b/server/src/controllers/uploadsController.ts
@@ -84,19 +84,9 @@ export const uploadsController = {
       const parseLimit = parseInt(limit || String(DEFAULT_PAGE_SIZE))
       const validLimit = Math.min(Math.max(1, parseLimit), MAX_PAGE_SIZE)
 
-      // Parse cursor if provided
-      let cursorData
-      if (cursor) {
-        try {
-          cursorData = JSON.parse(Buffer.from(cursor, 'base64').toString())
-        } catch (e) {
-          return c.json({ error: 'Invalid cursor' }, 400)
-        }
-      }
-
       const result = await uploadService.listUploads({
         limit: validLimit,
-        cursor: cursorData,
+        cursor,
       })
 
       return c.json({

--- a/server/src/types/index.ts
+++ b/server/src/types/index.ts
@@ -37,11 +37,11 @@ export interface ListQueryParams {
 
 export interface ListOptions {
   limit: number
-  cursor?: { timestamp: string; id: string }
+  cursor?: string
   // userId?: string
 }
 
-export interface ListResult {
+export interface FileListResult {
   files: any[]
   nextCursor: string | null
   hasMore: boolean

--- a/web/src/lib/components/FileList.svelte
+++ b/web/src/lib/components/FileList.svelte
@@ -59,7 +59,7 @@
 							? 'bg-base-200'
 							: ''} {file.progress === 0 ? 'animate-pulse' : ''}"
 					>
-						{#if file.progress > 0}
+						{#if file.progress}
 							<div
 								class="bg-primary/20 rounded-field absolute inset-0 h-full transition-all duration-200"
 								style="width: {file.progress}%;"

--- a/web/src/lib/components/ServerStatus.svelte
+++ b/web/src/lib/components/ServerStatus.svelte
@@ -1,73 +1,75 @@
 <!-- lib/components/ServerStatus.svelte -->
 <script lang="ts">
-	import { endpoint, serverStatus, showConfigModal } from '$lib/stores'
+	import { endpoint, online, uptime, counter, showConfigModal } from '$lib/stores'
 	import { get } from 'svelte/store'
 
 	let eventSource: EventSource | null = null
-	let countdownInterval: number | undefined = undefined
-
-	const updateServerStatus = (
-		updates: Partial<{
-			online: boolean
-			counting: boolean
-			countdown: number
-			uptime: string
-		}>,
-	) => {
-		serverStatus.update((status) => ({ ...status, ...updates }))
-	}
+	let countdownInterval: number | undefined
 
 	const resetConnection = () => {
-		if (eventSource) {
-			eventSource.close()
-			eventSource = null
-		}
+		eventSource?.close()
+		eventSource = null
+
 		if (countdownInterval !== undefined) {
 			clearInterval(countdownInterval)
 			countdownInterval = undefined
 		}
-		updateServerStatus({ online: false, counting: false, countdown: 0 })
+
+		online.set(false)
+		counter.set({ counting: false, countdown: 0 })
 	}
 
 	const setupEventSource = () => {
 		resetConnection()
 		eventSource = new EventSource(`${get(endpoint)}/status`)
+
 		eventSource.onopen = () => {
-			updateServerStatus({ online: true, countdown: 10, counting: false })
+			online.set(true)
+			counter.set({ counting: false, countdown: 10 })
 		}
+
 		eventSource.onerror = () => {
-			updateServerStatus({ online: false })
+			online.set(false)
 			setTimeout(() => {
-				if (!get(serverStatus).counting && countdownInterval === undefined) {
+				if (!get(counter).counting && countdownInterval === undefined) {
 					startCountdown()
 				}
 			}, 800)
 		}
+
 		eventSource.onmessage = (event) => {
-			updateServerStatus({
-				uptime: Math.floor(Number.parseFloat(event.data)).toString(),
-			})
+			const seconds = Math.floor(Number.parseFloat(event.data)).toString()
+			uptime.set(seconds)
 		}
+
+		/*
+		eventSource.onmessage = (event) => {
+			const seconds = Math.floor(parseFloat(event.data))
+			const formatted = new Date(seconds * 1000).toISOString().substring(11, 19)
+			uptime.set(formatted)
+		}
+		*/
 	}
 
+	// 10 seconds countdown
 	const startCountdown = () => {
 		if (countdownInterval !== undefined) return
 
-		updateServerStatus({ counting: true, countdown: 10 })
-		let count = 10
+		let cnt = 10
+		counter.set({ counting: true, countdown: cnt })
 
-		countdownInterval = setInterval(() => {
-			if (get(serverStatus).online || count <= 0) {
-				if (countdownInterval !== undefined) {
-					clearInterval(countdownInterval)
-					countdownInterval = undefined
-				}
-				updateServerStatus({ counting: false })
-				if (!get(serverStatus).online) setupEventSource()
+		const interval = setInterval(() => {
+			if (get(online) || cnt <= 0) {
+				clearInterval(interval)
+				countdownInterval = undefined
+				counter.update((c) => ({ ...c, counting: false }))
+				if (!get(online)) setupEventSource()
 			} else {
-				updateServerStatus({ countdown: --count })
+				counter.update((c) => ({ ...c, countdown: --cnt }))
 			}
 		}, 1000)
+
+		countdownInterval = interval
 	}
 
 	$effect(() => {
@@ -87,9 +89,9 @@
 	class="bg-base-200 rounded-field flex w-full items-center p-6"
 >
 	<div class="flex items-center">
-		{#if $serverStatus.online}
+		{#if $online}
 			<div class="status status-success mr-3 animate-bounce"></div>
-		{:else if $serverStatus.counting}
+		{:else if $counter.counting}
 			<div class="mr-3 inline-grid *:[grid-area:1/1]">
 				<div class="status status-error animate-ping"></div>
 				<div class="status status-error"></div>
@@ -97,13 +99,16 @@
 		{:else}
 			<span class="status status-warning mr-3"></span>
 		{/if}
+
 		<span class="text-base-content mt-1 truncate">
-			{#if $serverStatus.online}
-				Server Online - Uptime: {$serverStatus.uptime}
-			{:else if $serverStatus.counting}
+			{#if $online}
+				Server Online - Uptime: {$uptime}
+			{:else if $counter.counting}
 				Action Required - Reconnect in
 				<span class="countdown">
-					<span style="--value:{$serverStatus.countdown};">{$serverStatus.countdown}</span>
+					<span style="--value:{$counter.countdown};">
+						{$counter.countdown}
+					</span>
 				</span>
 			{:else}
 				Action Required - Reconnecting...

--- a/web/src/lib/index.ts
+++ b/web/src/lib/index.ts
@@ -1,1 +1,0 @@
-// place files you want to import through the `$lib` alias in this folder.

--- a/web/src/lib/stores.ts
+++ b/web/src/lib/stores.ts
@@ -1,27 +1,7 @@
 // lib/stores.ts
 import { writable } from 'svelte/store'
 import { persist } from '$lib/utils/storage'
-
-export type FileItem = {
-	id: string
-	name: string
-	size: number
-	type: string
-	time: string
-	icon: string
-	progress: number
-	thumb?: string
-	xhr?: XMLHttpRequest
-}
-
-export type TaskItem = {
-	id: string
-	status: string
-	created_at: string
-	updated_at?: string
-	result_path?: string
-	error?: string | null
-}
+import type { FileItem, TaskItem } from '$lib/types'
 
 export const files = writable<FileItem[]>([])
 export const tasks = writable<TaskItem[]>([])

--- a/web/src/lib/stores.ts
+++ b/web/src/lib/stores.ts
@@ -6,14 +6,13 @@ import type { FileItem, TaskItem } from '$lib/types'
 export const files = writable<FileItem[]>([])
 export const tasks = writable<TaskItem[]>([])
 
-export const serverStatus = writable<{
-	online: boolean
-	uptime: string
+export const uptime = writable('')
+export const online = writable(false)
+
+export const counter = writable<{
 	countdown: number
 	counting: boolean
 }>({
-	online: false,
-	uptime: '',
 	countdown: 10,
 	counting: false,
 })
@@ -25,7 +24,7 @@ export const showConfigModal = writable<boolean>(false)
 export const currentTab = writable<string>('files')
 
 export const token = persist<string>('token', '')
-export const endpoint = persist<string>('endpoint',	'/api')
+export const endpoint = persist<string>('endpoint', '/api')
 
 export const slashCommands: string[] = [
 	'extract-audio',

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -1,0 +1,20 @@
+export type FileItem = {
+    id: string
+    name: string
+    size: number
+    type: string
+    time: string
+    icon?: string
+    thumb?: string
+    progress?: number
+    xhr?: XMLHttpRequest
+}
+
+export type TaskItem = {
+    id: string
+    status: string
+    created_at: string
+    updated_at?: string
+    result_path?: string
+    error?: string | null
+}

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -1,20 +1,20 @@
 export type FileItem = {
-    id: string
-    name: string
-    size: number
-    type: string
-    time: string
-    icon?: string
-    thumb?: string
-    progress?: number
-    xhr?: XMLHttpRequest
+	id: string
+	name: string
+	size: number
+	type: string
+	time: string
+	icon?: string
+	thumb?: string
+	progress?: number
+	xhr?: XMLHttpRequest
 }
 
 export type TaskItem = {
-    id: string
-    status: string
-    created_at: string
-    updated_at?: string
-    result_path?: string
-    error?: string | null
+	id: string
+	status: string
+	created_at: string
+	updated_at?: string
+	result_path?: string
+	error?: string | null
 }

--- a/web/src/lib/utils/input.ts
+++ b/web/src/lib/utils/input.ts
@@ -1,5 +1,5 @@
 // lib/utils/input.ts
-import type { FileItem } from '$lib/stores'
+import type { FileItem } from '$lib/types'
 
 export function getCommandText(inputElement: HTMLDivElement): string {
 	let text = ''

--- a/web/src/lib/utils/items.ts
+++ b/web/src/lib/utils/items.ts
@@ -76,7 +76,7 @@ export async function fetchRemoteItems<T, R>({
 		}
 
 		const items = (json.data as R[]).map(transform)
-		store.update(current => (append ? [...current, ...items] : items))
+		store.update((current) => (append ? [...current, ...items] : items))
 
 		return {
 			nextCursor: json.pagination?.next_cursor ?? null,

--- a/web/src/lib/utils/items.ts
+++ b/web/src/lib/utils/items.ts
@@ -1,28 +1,45 @@
 // $lib/utils/items.ts
 import type { Writable } from 'svelte/store'
 
-export async function deleteRemoteItem({
-	id,
-	endpoint,
-	resource,
-	token = 'AUTH_TOKEN_PLACEHOLDER',
-}: {
+type DeleteOptions = {
 	id: string | number
 	endpoint: string
 	resource: string
 	token?: string
-}): Promise<boolean> {
+}
+
+type FetchOptions<T, R> = {
+	endpoint: string
+	resource: string
+	store: Writable<T[]>
+	transform: (raw: R) => T
+	token?: string
+	limit?: number
+	cursor?: string
+	append?: boolean
+}
+
+export async function deleteRemoteItem({
+	id,
+	endpoint,
+	resource,
+	token,
+}: DeleteOptions): Promise<boolean> {
 	const path = `${endpoint}/${resource}/${id}`
+
 	try {
 		const response = await fetch(path, {
 			method: 'DELETE',
-			headers: { Authorization: `Bearer ${token}` },
+			headers: token ? { Authorization: `Bearer ${token}` } : {},
 		})
+
 		const result = await response.json()
+
 		if (!response.ok) {
-			console.error(`Remote deletion failed:`, result)
+			console.error('Remote deletion failed:', result)
 			return false
 		}
+
 		console.log(`${resource} deleted successfully:`, result)
 		return true
 	} catch (error) {
@@ -31,34 +48,26 @@ export async function deleteRemoteItem({
 	}
 }
 
-export async function fetchRemoteItems<T>({
+export async function fetchRemoteItems<T, R>({
 	endpoint,
 	resource,
 	store,
 	transform,
-	token = 'AUTH_TOKEN_PLACEHOLDER',
+	token,
 	limit = 50,
 	cursor,
 	append = false,
-}: {
-	endpoint: string
-	resource: string
-	store: Writable<T[]>
-	transform: (raw: any) => T
-	token?: string
-	limit?: number
-	cursor?: string
-	append?: boolean
-}): Promise<{ nextCursor: string | null; hasMore: boolean }> {
+}: FetchOptions<T, R>): Promise<{ nextCursor: string | null; hasMore: boolean }> {
 	const params = new URLSearchParams({ limit: String(limit) })
 	if (cursor) params.set('cursor', cursor)
 
-	const url = `${endpoint}/${resource}?${params.toString()}`
+	const url = `${endpoint}/${resource}?${params}`
 
 	try {
 		const res = await fetch(url, {
-			headers: { Authorization: `Bearer ${token}` },
+			headers: token ? { Authorization: `Bearer ${token}` } : {},
 		})
+
 		const json = await res.json()
 
 		if (!res.ok || !json.success) {
@@ -66,9 +75,8 @@ export async function fetchRemoteItems<T>({
 			return { nextCursor: null, hasMore: false }
 		}
 
-		const items = json.data.map(transform) as T[]
-
-		store.update((current) => (append ? [...current, ...items] : items))
+		const items = (json.data as R[]).map(transform)
+		store.update(current => (append ? [...current, ...items] : items))
 
 		return {
 			nextCursor: json.pagination?.next_cursor ?? null,
@@ -80,28 +88,21 @@ export async function fetchRemoteItems<T>({
 	}
 }
 
-export async function fetchAllRemoteItems<T>({
+export async function fetchAllRemoteItems<T, R>({
 	endpoint,
 	resource,
 	store,
 	transform,
-	token = 'AUTH_TOKEN_PLACEHOLDER',
+	token,
 	limit = 10,
-}: {
-	endpoint: string
-	resource: string
-	store: Writable<T[]>
-	transform: (raw: any) => T
-	token?: string
-	limit?: number
-}): Promise<void> {
+}: Omit<FetchOptions<T, R>, 'cursor' | 'append'>): Promise<void> {
 	let cursor: string | undefined
 	let hasMore = true
 
 	store.set([])
 
 	while (hasMore) {
-		const result = await fetchRemoteItems({
+		const result = await fetchRemoteItems<T, R>({
 			endpoint,
 			resource,
 			store,

--- a/web/src/lib/utils/storage.ts
+++ b/web/src/lib/utils/storage.ts
@@ -1,26 +1,26 @@
 // lib/utils/storage.ts
-import { writable, type Writable } from 'svelte/store';
-import { browser } from '$app/environment';
+import { writable, type Writable } from 'svelte/store'
+import { browser } from '$app/environment'
 
 export function persist<T>(key: string, initialValue: T): Writable<T> {
 	const storedValue = browser
 		? (() => {
 				try {
-					const json = localStorage.getItem(key);
-					return json ? JSON.parse(json) : initialValue;
+					const json = localStorage.getItem(key)
+					return json ? JSON.parse(json) : initialValue
 				} catch {
-					return initialValue;
+					return initialValue
 				}
-		  })()
-		: initialValue;
+			})()
+		: initialValue
 
-	const store = writable<T>(storedValue);
+	const store = writable<T>(storedValue)
 
 	if (browser) {
 		store.subscribe((value) => {
-			localStorage.setItem(key, JSON.stringify(value));
-		});
+			localStorage.setItem(key, JSON.stringify(value))
+		})
 	}
 
-	return store;
+	return store
 }

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -1,17 +1,18 @@
+<!-- routes/+layout.svelte -->
 <script lang="ts">
 	import '../app.css'
 	import 'material-icons/iconfont/material-icons.css'
-	import { serverStatus, endpoint, files, tasks } from '$lib/stores'
+	import { online, endpoint, files, tasks } from '$lib/stores'
 	import { fetchAllRemoteItems } from '$lib/utils/items'
 	import type { FileItem } from '$lib/types'
 	import { get } from 'svelte/store'
 
 	const { children } = $props()
 
-	let wasOnline = get(serverStatus).online
+	let wasOnline = get(online)
 
 	$effect(() => {
-		if (!wasOnline && $serverStatus.online) {
+		if (!wasOnline && $online) {
 			const ep = get(endpoint)
 
 			fetchAllRemoteItems<FileItem, FileItem>({
@@ -33,7 +34,7 @@
 			})
 		}
 
-		wasOnline = $serverStatus.online
+		wasOnline = $online
 	})
 </script>
 

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -3,6 +3,7 @@
 	import 'material-icons/iconfont/material-icons.css'
 	import { serverStatus, endpoint, files, tasks } from '$lib/stores'
 	import { fetchAllRemoteItems } from '$lib/utils/items'
+	import type { FileItem } from '$lib/types'
 	import { get } from 'svelte/store'
 
 	const { children } = $props()
@@ -13,16 +14,12 @@
 		if (!wasOnline && $serverStatus.online) {
 			const ep = get(endpoint)
 
-			fetchAllRemoteItems({
+			fetchAllRemoteItems<FileItem, FileItem>({
 				endpoint: ep,
 				resource: 'uploads',
 				store: files,
 				transform: (raw) => ({
-					id: raw.id,
-					name: raw.file_name,
-					size: raw.file_size,
-					type: raw.mime_type,
-					time: raw.uploaded_at,
+					...raw,
 					icon: 'cloud_sync',
 					progress: 100,
 				}),
@@ -32,10 +29,11 @@
 				endpoint: ep,
 				resource: 'tasks',
 				store: tasks,
-				transform: (raw) => raw,
+				transform: (r) => r,
 			})
 		}
-		wasOnline = get(serverStatus).online
+
+		wasOnline = $serverStatus.online
 	})
 </script>
 

--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -12,7 +12,7 @@
 
 <!-- Desktop layout -->
 <div class="hidden h-screen md:flex">
-	<aside class="flex w-sm flex-col p-6 overflow-y-scroll max-h-screen">
+	<aside class="flex max-h-screen w-sm flex-col overflow-y-scroll p-6">
 		<div class="mb-6"><ServerStatus /></div>
 		<div class="mb-4"><FileUploader /></div>
 		<div class="tabs tabs-border mb-6">


### PR DESCRIPTION
Also changed `cursor` on the server, from `base64{time, uuid}` to `uuid` for simplicity