### PR TITLE
fix(web): replace space with non-breaking space

### DIFF
--- a/web/src/lib/components/CommandInput.svelte
+++ b/web/src/lib/components/CommandInput.svelte
@@ -215,7 +215,7 @@
 		const parent = textNode.parentNode
 		if (parent) {
 			parent.insertBefore(span, textNode.nextSibling)
-			parent.insertBefore(document.createTextNode(' '), span.nextSibling)
+			parent.insertBefore(document.createTextNode('\u00A0'), span.nextSibling)
 			parent.insertBefore(document.createTextNode(after), span.nextSibling?.nextSibling || null)
 		}
 

--- a/web/src/lib/components/TaskDetail.svelte
+++ b/web/src/lib/components/TaskDetail.svelte
@@ -64,10 +64,25 @@
 		)
 	}
 
+	let lastId: string | undefined = undefined
+	let lastUpdatedAt: string | undefined = undefined
+
 	$effect(() => {
-		if ($task && shouldLoadPreview($task)) {
-			loadPreviewBlob($task.id)
-		} else {
+		const id = $task?.id
+		const updatedAt = $task?.updated_at
+
+		if (id && (id !== lastId || updatedAt !== lastUpdatedAt)) {
+			lastId = id
+			lastUpdatedAt = updatedAt
+
+			if (shouldLoadPreview($task)) {
+				loadPreviewBlob(id)
+			} else {
+				revokeMediaUrl()
+			}
+		}
+
+		if (!id) {
 			revokeMediaUrl()
 		}
 	})


### PR DESCRIPTION
This commit ensures contenteditable space insertion works in Firefox and Safari